### PR TITLE
Refresh UI with modern light theme

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -78,17 +78,16 @@
   width: 2.25rem;
   height: 2.25rem;
   border-radius: 0.75rem;
-  background: linear-gradient(to bottom right, #0ea5e9, #8b5cf6);
-  box-shadow: 0 10px 15px -3px rgb(14 165 233 / 0.3);
+  background: linear-gradient(to bottom right, #3b82f6, #a855f7);
+  box-shadow: 0 2px 4px rgb(0 0 0 / 0.1);
 }
 
 /* Game card styles */
 .game-card {
   border-radius: 1rem;
-  border: 1px solid rgb(255 255 255 / 0.1);
-  background: rgb(255 255 255 / 0.05);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.3);
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 0.05);
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -99,8 +98,8 @@
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 9999px;
-  background: rgb(255 255 255 / 0.1);
-  border: 1px solid rgb(255 255 255 / 0.1);
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -127,13 +126,14 @@
   height: 2.25rem;
   padding: 0 1rem;
   border-radius: 9999px;
-  border: 1px solid rgb(255 255 255 / 0.1);
-  background: rgb(255 255 255 / 0.05);
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  color: #1e293b;
   transition: background-color 150ms ease-in-out;
 }
 
 .provider-link:hover {
-  background: rgb(255 255 255 / 0.1);
+  background: #e2e8f0;
 }
 
 .provider-link img {
@@ -153,31 +153,32 @@
   width: 0.375rem;
   height: 0.375rem;
   border-radius: 9999px;
-  background: #0ea5e9;
-  box-shadow: 0 0 10px rgb(14 165 233 / 0.7);
+  background: #3b82f6;
+  box-shadow: 0 0 10px rgb(59 130 246 / 0.7);
 }
 
 /* Loading and error states */
 .loading-card,
 .error-card,
 .empty-card {
-  border: 1px solid rgb(255 255 255 / 0.1);
+  border: 1px solid #e2e8f0;
   border-radius: 0.75rem;
   padding: 1.25rem;
+  background: #ffffff;
 }
 
 /* Week selector styles */
 .week-selector {
   height: 2rem;
   border-radius: 0.375rem;
-  background: rgb(255 255 255 / 0.05);
-  border: 1px solid rgb(255 255 255 / 0.1);
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
   font-size: 0.875rem;
   padding: 0 0.5rem;
-  color: #bae6fd;
+  color: #1e293b;
 }
 
 .week-selector:focus {
   outline: none;
-  box-shadow: 0 0 0 2px #0ea5e9;
+  box-shadow: 0 0 0 2px #3b82f6;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -15,34 +15,34 @@
   <!-- Custom Styles -->
   <link rel="stylesheet" href="css/styles.css">
 </head>
-<body class="bg-slate-950 text-slate-100 antialiased">
+<body class="bg-slate-50 text-slate-900 antialiased">
   <div id="app" class="app-container">
     <!-- Header Section -->
-    <header class="app-header">
+    <header class="app-header bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-md">
       <div class="flex items-center gap-3 font-bold">
         <div class="app-logo" aria-hidden="true"></div>
         <div>
           <div class="text-base tracking-tight">Where To Watch NFL</div>
-          <div class="text-slate-400 text-sm">{{ timezoneText }}</div>
+          <div class="text-white/80 text-sm">{{ timezoneText }}</div>
         </div>
       </div>
-      <div class="text-slate-400 text-sm">{{ contextText }}</div>
+      <div class="text-white/80 text-sm">{{ contextText }}</div>
     </header>
 
     <!-- Main Content -->
-    <main class="app-main">
+    <main class="app-main max-w-6xl mx-auto">
       <!-- Section Header with Week Selector -->
       <div class="flex flex-wrap items-center gap-3 mb-2">
         <h2 class="m-0 text-xl font-semibold">{{ sectionTitle }}</h2>
-        <div class="text-slate-400 text-sm">{{ sectionSubtitle }}</div>
-        
+        <div class="text-slate-600 text-sm">{{ sectionSubtitle }}</div>
+
         <!-- Week Selection Dropdown -->
         <div v-if="availableFutureWeeks.length" class="ml-auto flex items-center gap-2">
-          <label for="weekSelect" class="text-slate-400 text-sm">Jump to:</label>
-          <select 
-            id="weekSelect" 
-            :value="selectedWeek ?? ''" 
-            @change="onWeekChange" 
+          <label for="weekSelect" class="text-slate-600 text-sm">Jump to:</label>
+          <select
+            id="weekSelect"
+            :value="selectedWeek ?? ''"
+            @change="onWeekChange"
             class="week-selector"
           >
             <option value="" disabled selected>Select week…</option>
@@ -54,24 +54,24 @@
       </div>
 
       <!-- Loading and Error States -->
-      <div v-if="error" class="error-card text-slate-400 text-sm" role="alert">
+      <div v-if="error" class="error-card text-slate-600 text-sm" role="alert">
         There was a problem loading the schedule. Please refresh to try again.
       </div>
 
-      <div v-else-if="loading" class="loading-card text-slate-400 text-sm" role="status" aria-live="polite">
+      <div v-else-if="loading" class="loading-card text-slate-600 text-sm" role="status" aria-live="polite">
         Loading schedule…
       </div>
 
       <!-- Games Display -->
       <template v-else>
-        <div v-if="displayGroups.length === 0" class="empty-card text-slate-400 text-sm">
+        <div v-if="displayGroups.length === 0" class="empty-card text-slate-600 text-sm">
           No games found.
         </div>
         
         <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           <template v-for="group in displayGroups" :key="group.key">
             <!-- Date Group Header -->
-            <div class="col-span-full flex items-center gap-2 text-slate-400 font-semibold mt-2">
+            <div class="col-span-full flex items-center gap-2 text-slate-500 font-semibold mt-2">
               <span class="date-indicator"></span>
               <span>{{ group.label }}</span>
             </div>
@@ -103,7 +103,7 @@
                 </div>
                 
                 <!-- VS Indicator -->
-                <div class="text-slate-400 font-bold text-center px-2">@</div>
+                <div class="text-slate-500 font-bold text-center px-2">@</div>
                 
                 <!-- Home Team -->
                 <div class="flex items-center gap-2 min-w-0 justify-end">
@@ -125,14 +125,14 @@
               </div>
 
               <!-- Game Time -->
-              <div class="text-slate-400 text-sm">
+              <div class="text-slate-600 text-sm">
                 {{ fmtTimeOnly(kickoffDate(game)) }}
               </div>
 
               <!-- Providers -->
               <div class="flex items-center gap-2 flex-wrap">
                 <template v-if="pickProviders(game).length === 0">
-                  <span class="text-slate-400 text-sm">Providers to be announced</span>
+                  <span class="text-slate-600 text-sm">Providers to be announced</span>
                 </template>
                 <template v-else>
                   <a 
@@ -163,9 +163,9 @@
     </main>
 
     <!-- Footer -->
-    <footer class="app-footer text-slate-400 text-sm">
+    <footer class="app-footer text-slate-500 text-sm">
       <div class="text-xs opacity-75">
-        <strong>Legal Disclaimer:</strong> All NFL team names, logos, and trademarks are the property of the National Football League and its respective teams. 
+        <strong>Legal Disclaimer:</strong> All NFL team names, logos, and trademarks are the property of the National Football League and its respective teams.
         All streaming service names, logos, and trademarks (including but not limited to Netflix, Prime Video, NFL+, ESPN, CBS, NBC, FOX, Amazon, YouTube, and others) are the property of their respective owners.
         This website is not affiliated with, endorsed by, or sponsored by the NFL, its teams, or any streaming providers. 
         All trademarks and logos are used for informational purposes only under fair use guidelines.


### PR DESCRIPTION
## Summary
- overhaul look and feel with light theme and gradient header
- restyle cards, provider chips and selectors for better readability
- ensure consistent neutral colors across layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa494f44c833382a4cf2405be5084