### PR TITLE
Add configurable filters for streaming providers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,6 +53,26 @@
         </div>
       </div>
 
+      <!-- Streaming Provider Filters -->
+      <div class="flex flex-wrap items-center gap-2 mb-4">
+        <label for="providerFilter" class="text-slate-400 text-sm">Providers:</label>
+        <input
+          id="providerFilter"
+          v-model="providerFilterText"
+          type="text"
+          placeholder="e.g., NFL+,Prime"
+          class="week-selector"
+        />
+        <label for="regionFilter" class="text-slate-400 text-sm">Regions:</label>
+        <input
+          id="regionFilter"
+          v-model="regionFilterText"
+          type="text"
+          placeholder="e.g., US,CA"
+          class="week-selector"
+        />
+      </div>
+
       <!-- Loading and Error States -->
       <div v-if="error" class="error-card text-slate-400 text-sm" role="alert">
         There was a problem loading the schedule. Please refresh to try again.

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30,7 +30,22 @@ export function createNFLApp() {
       const now = ref(new Date());
       const timezone = ref(getUserTimezone());
       const selectedWeek = ref(null);
+      const providerFilterText = ref('');
+      const regionFilterText = ref('');
       let nowInterval;
+
+      const providerFilters = computed(() =>
+        providerFilterText.value
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean)
+      );
+      const regionFilters = computed(() =>
+        regionFilterText.value
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean)
+      );
 
       // Computed properties for season timeline
       const currentWeek = computed(() => {
@@ -246,6 +261,12 @@ export function createNFLApp() {
         return groupGamesByDate(filteredGames.value);
       });
 
+      const pickProviders = (game) =>
+        processProviders(game, {
+          includeProviders: providerFilters.value,
+          includeRegions: regionFilters.value
+        });
+
       // Event handlers
       const handleWeekChange = (event) => {
         const raw = event && event.target ? event.target.value : '';
@@ -312,6 +333,8 @@ export function createNFLApp() {
         loading,
         error,
         selectedWeek,
+        providerFilterText,
+        regionFilterText,
         
         // Computed properties
         timezoneText,
@@ -323,7 +346,7 @@ export function createNFLApp() {
         availableFutureWeeks,
         
         // Methods
-        pickProviders: processProviders,
+        pickProviders,
         faviconUrl: getFaviconUrl,
         teamLogoUrl: getTeamLogoUrl,
         fmtTimeOnly: formatTimeOnly,


### PR DESCRIPTION
## Summary
- allow users to specify provider and region filters through new inputs
- support dynamic filters in `processProviders` to hide disallowed streaming options

## Testing
- `node --check public/js/utils.js`
- `node --check public/js/app.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09b3e93ec833382111e5167737d28